### PR TITLE
LA-2251 array replication bug fixed

### DIFF
--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -6,17 +6,9 @@ import { JSONEditor } from "../lib";
 
 const App = () => (
   <div>
-    <h3>Using default styles</h3>
+    <h3>Simple JSON Editor</h3>
     <JSONEditor
       data={data}
-      view="dual"
-      collapsible
-      onChange={this.onJsonChange}
-    />
-    <h3>Using customized styles</h3>
-    <JSONEditor
-      data={data}
-      view="dual"
       collapsible
       onChange={this.onJsonChange}
       styles={styles}
@@ -117,40 +109,42 @@ const styles = {
   },
 };
 
-const data = {
-  mobile: {
-    possibleCountryCodes: ["KE", "UG", "TZ"],
-    possibleLengths: {
-      national: "5",
-      sub_national: "7",
+const data =
+ 
+  {
+    name: 'pepcus',
+    age: null,
+    match :true,
+    address: [
+      'Panyu Shiqiao on Canton',
+      'Tianhe',
+      {
+        city: 'Indore',
+      },
+    ],
+    others: {
+      id: 1246,
+      joinTime: '2017-08-20. 10:20',
+      description: 'another',
     },
-    exampleNumber: 40123,
-    nationalNumberPattern: "4\\d{4}",
-  },
-  id: "AC",
-  is_valid_number: true,
-  generalDesc: {
-    nationalNumberPattern: "[46]\\d{4}|[01589]\\d{5}",
-  },
-  countryCode: "247",
-  uan: {
-    possibleLengths: {
-      national: "6",
-    },
-    exampleNumber: 542011,
-    nationalNumberPattern: "[01589]\\d{5}",
-  },
-  references: {
-    sourceUrl: "http://www.itu.int/oth/T02020000AF/en",
-  },
-  internationalPrefix: "00",
-  fixedLine: {
-    possibleLengths: {
-      national: "5",
-    },
-    exampleNumber: 62889,
-    nationalNumberPattern: "6[2-467]\\d{3}",
-  },
-};
+    "employees":[    
+        {"name":"Ram", "email":"ram@gmail.com", "age":23},    
+        {"name":"Shyam", "email":"shyam23@gmail.com", "age":28},  
+        {"name":"John", "email":"john@gmail.com", "age":33},    
+        {"name":"Bob", "email":"bob32@gmail.com", "age":41}   
+    ]  ,
+    "member":[    
+        {"name":"Ram", "email":"ram@gmail.com", "age":23},    
+        {"name":"Shyam", "email":"shyam23@gmail.com", "age":28},  
+        {"name":"John", "email":"john@gmail.com", "age":33},    
+        {"name":"Bob", "email":"bob32@gmail.com", "age":41}   
+    ]  ,
+    "players":[    
+        {"name":"Ram", "email":"ram@gmail.com", "age":23},    
+        {"name":"Shyam", "email":"shyam23@gmail.com", "age":28},  
+        {"name":"John", "email":"john@gmail.com", "age":33},    
+        {"name":"Bob", "email":"bob32@gmail.com", "age":41}   
+    ]  
+  }
 
 export default App;

--- a/src/lib/JSONEditor.js
+++ b/src/lib/JSONEditor.js
@@ -130,6 +130,7 @@ export default class JSONEditor extends React.Component {
     if (isArray(data)) {
       if (marginLeft > 0) {
         //special case to avoid showing root
+        // parent node
         elems.push(
           <ParentLabel
             key={getKey("parent_label", currentKey, parentKeyPath, marginLeft)}
@@ -163,6 +164,7 @@ export default class JSONEditor extends React.Component {
     } else if (isObject(data)) {
       if (marginLeft > 0) {
         //special case to avoid showing root
+        // root
         elems.push(
           <ParentLabel
             key={getKey("parent_label", currentKey, parentKeyPath, marginLeft)}
@@ -254,8 +256,14 @@ export default class JSONEditor extends React.Component {
   addElement = (parent) => {
     let newKey = null;
     if (isArray(parent)) {
-      parent.push("");
-      newKey = parent.length - 1;
+      if (typeof parent[0] == 'object') {
+				var obj2 = JSON.parse(JSON.stringify(parent[parent.length - 1]));
+				parent.splice(parent.length - 1, 0, obj2);
+				newKey = parent.length - 1;
+			} else {
+				parent.push('');
+				newKey = parent.length - 1;
+			}      
     } else {
       newKey = EDIT_KEY;
       parent[newKey] = "";


### PR DESCRIPTION
Array replication results in the empty key-value pair when we click the plus icon.  
![beforeLA-2251](https://github.com/pepcus-Aish/SimpleJSONEditorDemo/assets/141809285/b3a9f248-c1c8-457b-b524-a609fa6e6320)

which is not our desired case. 
after we can now replicate the last node of the array of objects case.

![after-LA2251](https://github.com/pepcus-Aish/SimpleJSONEditorDemo/assets/141809285/444119d6-6960-4934-a258-f2157b325866)

In the first picture, we could see the last element was added as a single key-value pair but in the second picture we can see the last node is replicated as an object which is required.
Moreover, sample data JSON is also changed to check every scenario for the editor.